### PR TITLE
Option to disable haptic feedback + to close when the blur view is tapped

### DIFF
--- a/drawer-view.podspec
+++ b/drawer-view.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 #
 
 s.name         = "drawer-view"
-s.version      = "1.0.1"
+s.version      = "1.0.2"
 s.summary      = "📤 Drawer View is a custom UI component replication of Apple's Apple Music player and Shortcuts components view"
 
 # This description is used to generate tags and improve search results.

--- a/drawer-view/DrawerView.swift
+++ b/drawer-view/DrawerView.swift
@@ -193,6 +193,20 @@ public class DrawerView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // In some cases (seems to depend on the view (controller) hierarchy)
+    // on has to call this function BEFORE the first animation to make it look right.
+    // Otherwise it may look like the component is expanding from the origin of its
+    // superview instead of appearing from the bottom.
+    public func setInitialFrame(_ frame: CGRect) {
+        self.blurEffectView?.frame = frame
+        
+        var initialFrame = frame
+        initialFrame.origin.y = initialFrame.size.height
+        initialFrame.size.height = 0
+        
+        self.frame = initialFrame
+    }
+    
     deinit {
         removeGestureRecognizer(tapGesture)
         removeGestureRecognizer(panGesture)

--- a/drawer-view/DrawerView.swift
+++ b/drawer-view/DrawerView.swift
@@ -35,7 +35,7 @@ public class DrawerView: UIView {
     
     public private(set) var currentState: State = .closed {
         didSet {
-            if givesHapticFeedback {
+            if givesHapticFeedback {
                 hapticFeedback.impactOccurred()
             }
             onStateChangeClosure(currentState)
@@ -47,7 +47,7 @@ public class DrawerView: UIView {
     /// The component will change its state to .closed when child views are interacted
     @IBInspectable public var closeOnChildViewTaps              = false
     /// The component will change its state to .closed when a tap occurs out of itself
-    @IBInspectable public var closeOnTapOutside                 = false
+    @IBInspectable public var closeOnBlurTapped                 = false
     /// The component will give the user haptic feedback at after state change
     @IBInspectable public var givesHapticFeedback               = true
     @IBInspectable public var animationDuration: TimeInterval   = 1.5
@@ -289,7 +289,7 @@ public class DrawerView: UIView {
     }
     
     @objc private func drawerViewGestureTappedOut(recognizer: UITapGestureRecognizer) {
-        if closeOnTapOutside {
+        if closeOnBlurTapped {
             animateTransitionIfNeeded(to: .closed, duration: animationDuration)
         }
     }

--- a/drawer-view/DrawerView.swift
+++ b/drawer-view/DrawerView.swift
@@ -44,6 +44,8 @@ public class DrawerView: UIView {
     @IBInspectable public var closeOnRotation                   = false
     /// The component will change its state to .closed when child views are interacted
     @IBInspectable public var closeOnChildViewTaps              = false
+    /// The component will change its state to .closed when a tap occurs out of itself
+    @IBInspectable public var closeOnTapOutside                 = false
     @IBInspectable public var animationDuration: TimeInterval   = 1.5
     @IBInspectable public var animationDampingRatio: CGFloat    = 1.0
     @IBInspectable public var cornerRadius: CGFloat             = 40.0
@@ -99,7 +101,14 @@ public class DrawerView: UIView {
         }
         let blurEffect = UIBlurEffect(style: style)
         let effectView = UIVisualEffectView(effect: blurEffect)
+        effectView.addGestureRecognizer(outTapGesture)
         return effectView
+    }()
+    
+    private lazy var outTapGesture: UITapGestureRecognizer = {
+        let recognizer = UITapGestureRecognizer()
+        recognizer.addTarget(self, action: #selector(drawerViewGestureTappedOut(recognizer:)))
+        return recognizer
     }()
     
     private lazy var tapGesture: UITapGestureRecognizer = {
@@ -259,6 +268,12 @@ public class DrawerView: UIView {
         
         transitionAnimator.startAnimation()
         runningAnimators += [transitionAnimator]
+    }
+    
+    @objc private func drawerViewGestureTappedOut(recognizer: UITapGestureRecognizer) {
+        if closeOnTapOutside {
+            animateTransitionIfNeeded(to: .closed, duration: animationDuration)
+        }
     }
     
     @objc private func drawerViewGestureTapped(recognizer: UITapGestureRecognizer) {

--- a/drawer-view/DrawerView.swift
+++ b/drawer-view/DrawerView.swift
@@ -35,7 +35,9 @@ public class DrawerView: UIView {
     
     public private(set) var currentState: State = .closed {
         didSet {
-            hapticFeedback.impactOccurred()
+            if givesHapticFeedback {
+                hapticFeedback.impactOccurred()
+            }
             onStateChangeClosure(currentState)
         }
     }
@@ -46,6 +48,8 @@ public class DrawerView: UIView {
     @IBInspectable public var closeOnChildViewTaps              = false
     /// The component will change its state to .closed when a tap occurs out of itself
     @IBInspectable public var closeOnTapOutside                 = false
+    /// The component will give the user haptic feedback at after state change
+    @IBInspectable public var givesHapticFeedback               = true
     @IBInspectable public var animationDuration: TimeInterval   = 1.5
     @IBInspectable public var animationDampingRatio: CGFloat    = 1.0
     @IBInspectable public var cornerRadius: CGFloat             = 40.0


### PR DESCRIPTION
* f4c0cb4 and 7e1fdd2 add the closeOnBlurTapped option
* f1f33f9 adds an option to disable the haptic feedback
* 9b8553e adds a setInitialFrame method, that can be called after the initialization but before any animation, to fix an issue when adding a `DrawerView` to a superview of type UITabBar, that would result in the first `.open` animation looking like both the blur view and the drawer itself were being zoomed from the origin (top-left corner usually).