### PR TITLE
Touch delegation

### DIFF
--- a/drawer-view/DrawerView.swift
+++ b/drawer-view/DrawerView.swift
@@ -46,6 +46,8 @@ public class DrawerView: UIView {
     @IBInspectable public var closeOnRotation                   = false
     /// The component will change its state to .closed when child views are interacted
     @IBInspectable public var closeOnChildViewTaps              = false
+    /// The component will change its state to .closed when the drawer is tapped
+    @IBInspectable public var closeOnDrawerTaps                 = true
     /// The component will change its state to .closed when a tap occurs out of itself
     @IBInspectable public var closeOnBlurTapped                 = false
     /// The component will give the user haptic feedback at after state change
@@ -295,6 +297,7 @@ public class DrawerView: UIView {
     }
     
     @objc private func drawerViewGestureTapped(recognizer: UITapGestureRecognizer) {
+        guard closeOnDrawerTaps else { return }
         let state = currentState.opposite
         animateTransitionIfNeeded(to: state, duration: animationDuration)
     }

--- a/drawer-view/DrawerView.swift
+++ b/drawer-view/DrawerView.swift
@@ -120,12 +120,14 @@ public class DrawerView: UIView {
     private lazy var tapGesture: UITapGestureRecognizer = {
         let recognizer = UITapGestureRecognizer()
         recognizer.addTarget(self, action: #selector(drawerViewGestureTapped(recognizer:)))
+        recognizer.delegate = self
         return recognizer
     }()
     
     private lazy var panGesture: ImmediatePanGestureRecognizer = {
         let recognizer = ImmediatePanGestureRecognizer()
         recognizer.addTarget(self, action: #selector(drawerViewGesturePanned(recognizer:)))
+        recognizer.delegate = self
         return recognizer
     }()
     
@@ -404,4 +406,20 @@ private extension DrawerView {
         
         sholdRecalculateConstraints = false
     }
+}
+
+extension DrawerView : UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        for subView in self.subviews {
+            guard let subView = subView as? DrawerViewTouchHandling else { continue }
+            if subView.interceptsTouch(touch) {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+@objc public protocol DrawerViewTouchHandling {
+    @objc func interceptsTouch(_ touch: UITouch) -> Bool
 }


### PR DESCRIPTION
This change is a bit more involved that my other PR, that's why it's separate.
It fixes #3, but it involves asking subviews to conform to a protocol. 
It's not a fix I like, and I'd better have a solution that is only done with overrides of `hitTest` or `point(inside: CGPoint, with: UIEvent?)` – but I could not find a way.